### PR TITLE
ユーザモデルからライブラリを参照できる様にする

### DIFF
--- a/common/models/remp-user.json
+++ b/common/models/remp-user.json
@@ -14,6 +14,14 @@
       "foreignKey": ""
     }
   },
-  "acls": [],
+  "acls": [
+    {
+      "accessType": "EXECUTE",
+      "principalType": "ROLE",
+      "principalId": "$owner",
+      "permission": "ALLOW",
+      "property": "__get__libraries"
+    }
+  ],
   "methods": []
 }

--- a/common/models/remp-user.json
+++ b/common/models/remp-user.json
@@ -21,6 +21,13 @@
       "principalId": "$owner",
       "permission": "ALLOW",
       "property": "__get__libraries"
+    },
+    {
+      "accessType": "EXECUTE",
+      "principalType": "ROLE",
+      "principalId": "$owner",
+      "permission": "ALLOW",
+      "property": "__create__libraries"
     }
   ],
   "methods": []


### PR DESCRIPTION
解決したいこと
-----

- ユーザモデルからライブラリを参照できる様にACLを設定します
- 具体的には以下の様なエントリポイントをアクセスできる様にします
 - ```/api/rempusers/:id/libraries``` に対するGETとPOST