### PR TITLE
Searchモデル追加

### DIFF
--- a/common/models/remp-user.json
+++ b/common/models/remp-user.json
@@ -52,6 +52,20 @@
       "principalId": "$owner",
       "permission": "ALLOW",
       "property": "__create__inbox"
+    },
+    {
+      "accessType": "EXECUTE",
+      "principalType": "ROLE",
+      "principalId": "$owner",
+      "permission": "ALLOW",
+      "property": "__create__searches"
+    },
+    {
+      "accessType": "EXECUTE",
+      "principalType": "ROLE",
+      "principalId": "$owner",
+      "permission": "ALLOW",
+      "property": "__get__searches"
     }
   ],
   "methods": []

--- a/common/models/remp-user.json
+++ b/common/models/remp-user.json
@@ -17,6 +17,11 @@
       "type": "hasOne",
       "model": "Inbox",
       "foreignKey": ""
+    },
+    "searches": {
+      "type": "hasMany",
+      "model": "Search",
+      "foreignKey": ""
     }
   },
   "acls": [

--- a/common/models/search.js
+++ b/common/models/search.js
@@ -1,0 +1,3 @@
+module.exports = function(Search) {
+
+};

--- a/common/models/search.json
+++ b/common/models/search.json
@@ -17,6 +17,11 @@
       "type": "hasMany",
       "model": "Music",
       "foreignKey": ""
+    },
+    "rempUser": {
+      "type": "belongsTo",
+      "model": "RempUser",
+      "foreignKey": ""
     }
   },
   "acls": [],

--- a/common/models/search.json
+++ b/common/models/search.json
@@ -12,7 +12,13 @@
     }
   },
   "validations": [],
-  "relations": {},
+  "relations": {
+    "musics": {
+      "type": "hasMany",
+      "model": "Music",
+      "foreignKey": ""
+    }
+  },
   "acls": [],
   "methods": []
 }

--- a/common/models/search.json
+++ b/common/models/search.json
@@ -1,0 +1,18 @@
+{
+  "name": "Search",
+  "base": "PersistedModel",
+  "idInjection": true,
+  "options": {
+    "validateUpsert": true
+  },
+  "properties": {
+    "keyword": {
+      "type": "string",
+      "required": true
+    }
+  },
+  "validations": [],
+  "relations": {},
+  "acls": [],
+  "methods": []
+}

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -42,10 +42,6 @@
     "dataSource": "db",
     "public": true
   },
-  "search": {
-    "dataSource": "db",
-    "public": true
-  },
   "Search": {
     "dataSource": "db",
     "public": true

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -41,5 +41,13 @@
   "Inbox": {
     "dataSource": "db",
     "public": true
+  },
+  "search": {
+    "dataSource": "db",
+    "public": true
+  },
+  "Search": {
+    "dataSource": "db",
+    "public": true
   }
 }


### PR DESCRIPTION
- 解決したいこと
 - REMP上で楽曲を検索した際にその結果を格納するためのSearchモデルを新設します
 - SearchモデルにはPlaylist, Inboxモデルと同様にMusicモデルが所属します