### PR TITLE
楽曲検索APIのテスト追加

### DIFF
--- a/common/models/search.json
+++ b/common/models/search.json
@@ -24,6 +24,19 @@
       "foreignKey": ""
     }
   },
-  "acls": [],
+  "acls": [
+    {
+      "accessType": "*",
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "DENY"
+    },
+    {
+      "accessType": "READ",
+      "principalType": "ROLE",
+      "principalId": "$authenticated",
+      "permission": "ALLOW"
+    }
+  ],
   "methods": []
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "devDependencies": {
     "chai": "^3.0.0",
     "jshint": "^2.5.6",
-    "loopback-testing": "^1.1.0"
+    "loopback-testing": "^1.1.0",
+    "sepia": "^2.0.1"
   },
   "repository": {
     "type": "",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   "devDependencies": {
     "chai": "^3.0.0",
     "jshint": "^2.5.6",
-    "loopback-testing": "^1.1.0",
-    "sepia": "^2.0.1"
+    "loopback-testing": "^1.1.0"
   },
   "repository": {
     "type": "",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server/server.js",
   "scripts": {
-    "test": "NODE_ENV=\"testing\" ./node_modules/loopback-testing/node_modules/.bin/mocha -R nyan --recursive"
+    "test": "NODE_ENV=\"testing\" ./node_modules/loopback-testing/node_modules/.bin/mocha -R spec --recursive"
   },
   "dependencies": {
     "compression": "^1.0.3",

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -127,6 +127,12 @@ describe('/api/users', function() {
       });
     });
 
+    lt.describe.whenCalledByUser(user2, 'GET', '/api/searches/1', searchParams, function() {
+      it('楽曲の検索結果一覧を取得できる', function() {
+        assert.equal(this.res.statusCode, 200);
+      });
+    });
+
     lt.describe.whenCalledByUser(user2, 'POST', '/api/users/2/searches', {keyword:""}, function() {
       it('検索キーワードが無い場合は検索が行えない', function() {
         assert.equal(this.res.statusCode, 422);

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -14,6 +14,13 @@ describe('/api/users', function() {
     password: "tester2remp"
   };
 
+  var user3 = {
+    id: 3,
+    email: "tester3@remp.jp",
+    username: "tester3",
+    password: "tester3remp"
+  };
+
   var createPlayList = {
     title: "REMP PLAY LIST",
     published: true
@@ -127,17 +134,30 @@ describe('/api/users', function() {
       });
     });
 
-    lt.describe.whenCalledByUser(user2, 'GET', '/api/searches/1', searchParams, function() {
-      it('楽曲の検索結果一覧を取得できる', function() {
-        assert.equal(this.res.statusCode, 200);
-      });
-    });
-
     lt.describe.whenCalledByUser(user2, 'POST', '/api/users/2/searches', {keyword:""}, function() {
       it('検索キーワードが無い場合は検索が行えない', function() {
         assert.equal(this.res.statusCode, 422);
         assert.equal(this.res.body.error.name, "ValidationError");
       });
     });
+
+    lt.describe.whenCalledByUser(user2, 'GET', '/api/searches/1', function() {
+      it('楽曲の検索結果一覧を取得できる', function() {
+        assert.equal(this.res.statusCode, 200);
+      });
+    });
+
+    lt.describe.whenCalledByUser(user3, 'GET', '/api/searches/1', function() {
+      it('ログインしたユーザは他人の楽曲の検索結果一覧を取得できる', function() {
+        assert.equal(this.res.statusCode, 200);
+      });
+    });
+
+    lt.describe.whenCalledRemotely('GET', '/api/searches/1', function() {
+      it('未ログインの状態で検索結果は取得できない', function() {
+        assert.equal(this.res.statusCode, 401);
+      });
+    });
+
   });
 });

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -19,6 +19,10 @@ describe('/api/users', function() {
     published: true
   };
 
+  var searchParams = {
+    keyword: "YMO"
+  };
+
   lt.beforeEach.withApp(app);
 
   lt.describe.whenCalledRemotely('GET', '/api/users', function() {
@@ -112,6 +116,20 @@ describe('/api/users', function() {
     lt.describe.whenCalledByUser(user2, 'POST', '/api/users/1/playlists', createPlayList, function() {
       it('ログインユーザであっても他人のプレイリスを作成できない', function() {
         assert.equal(this.res.statusCode, 401);
+      });
+    });
+  });
+
+  describe('ユーザによる曲の検索操作', function() {
+    lt.describe.whenCalledByUser(user2, 'POST', '/api/users/2/searches', searchParams, function() {
+      it('APIを介して楽曲の検索ができる', function() {
+        assert.equal(this.res.statusCode, 200);
+      });
+    });
+
+    lt.describe.whenCalledByUser(user2, 'POST', '/api/users/2/searches', {keyword:""}, function() {
+      it('検索キーワードが無い場合は検索が行えない', function() {
+        assert.equal(this.res.statusCode, 422);
       });
     });
   });

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -130,6 +130,7 @@ describe('/api/users', function() {
     lt.describe.whenCalledByUser(user2, 'POST', '/api/users/2/searches', {keyword:""}, function() {
       it('検索キーワードが無い場合は検索が行えない', function() {
         assert.equal(this.res.statusCode, 422);
+        assert.equal(this.res.body.error.name, "ValidationError");
       });
     });
   });


### PR DESCRIPTION
### 解決したいこと
- 楽曲検索を行った場合のテストを追加します
 - ```/api/users/:id/searches``` 及び、 ```/api/searches/:id``` を対象とします
- 併せてMochaによるテスト出力の形式を ```spec``` に変更します
