### PR TITLE
プレイリスト操作(楽曲追加、削除) のテストを追加

### DIFF
--- a/common/models/music.js
+++ b/common/models/music.js
@@ -1,3 +1,4 @@
 module.exports = function(Music) {
-
+  var urlValidation = /^(ht|f)tps?:\/\/[a-z0-9-\.]+\.[a-z]{2,4}\/?([^\s<>\#%"\,\{\}\\|\\\^\[\]`]+)?$/;
+  Music.validatesFormatOf('url', {with: urlValidation, message: 'Passed invnalid URL strings'});
 };

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -32,7 +32,11 @@ describe('/api/users', function() {
     keyword: "YMO"
   };
 
-  var alicePlaylistId = null;
+  var musicParams = {
+    title: "BTTB",
+    type: "youtube",
+    url: "https://www.youtube.com/watch?v=btyhpyJTyXg"
+  };
 
   lt.beforeEach.withApp(app);
 
@@ -123,7 +127,6 @@ describe('/api/users', function() {
     lt.describe.whenCalledByUser(userAlice, 'POST', '/api/users/2/playlists', createPlayList, function() {
       it('ログインユーザはユーザのプレイリスを作成できる', function() {
         assert.equal(this.res.statusCode, 200);
-        alicePlaylistId = res.body.id;
       });
     });
 
@@ -135,6 +138,20 @@ describe('/api/users', function() {
 
     lt.describe.whenCalledByUser(userAlice, 'POST', '/api/users/1/playlists', createPlayList, function() {
       it('ログインユーザであっても他人のプレイリスを作成できない', function() {
+        assert.equal(this.res.statusCode, 401);
+      });
+    });
+  });
+
+  describe('ユーザによる曲のプレイリスト操作', function() {
+    lt.describe.whenCalledByUser(userAlice, 'POST', '/api/playlists/1/musics', musicParams, function() {
+      it('プレイリストの所有者はプレイリストに楽曲を1曲登録できる', function() {
+        assert.equal(this.res.statusCode, 200);
+      });
+    });
+
+    lt.describe.whenCalledByUser(userBob, 'POST', '/api/playlists/1/musics', musicParams, function() {
+      it('プレイリストの所有者以外はプレイリストに楽曲を1曲登録できない', function() {
         assert.equal(this.res.statusCode, 401);
       });
     });

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -32,6 +32,8 @@ describe('/api/users', function() {
     keyword: "YMO"
   };
 
+  var alicePlaylistId = null;
+
   lt.beforeEach.withApp(app);
 
   lt.describe.whenCalledRemotely('GET', '/api/users', function() {
@@ -121,6 +123,7 @@ describe('/api/users', function() {
     lt.describe.whenCalledByUser(userAlice, 'POST', '/api/users/2/playlists', createPlayList, function() {
       it('ログインユーザはユーザのプレイリスを作成できる', function() {
         assert.equal(this.res.statusCode, 200);
+        alicePlaylistId = res.body.id;
       });
     });
 

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -144,6 +144,18 @@ describe('/api/users', function() {
   });
 
   describe('ユーザによる曲のプレイリスト操作', function() {
+    lt.describe.whenCalledByUser(userAlice, 'POST', '/api/playlists/1/musics', {title:"NG"}, function() {
+      it('楽曲のURLが無ければプレイリストに登録できない', function() {
+        assert.equal(this.res.statusCode, 422);
+      });
+    });
+
+    lt.describe.whenCalledByUser(userAlice, 'POST', '/api/playlists/1/musics', {title:"NG", type:"youtube", url:"http"}, function() {
+      it('不正なURLの楽曲はプレイリストに登録できない', function() {
+        assert.equal(this.res.statusCode, 422);
+      });
+    });
+
     lt.describe.whenCalledByUser(userAlice, 'POST', '/api/playlists/1/musics', musicParams, function() {
       it('プレイリストの所有者はプレイリストに楽曲を1曲登録できる', function() {
         assert.equal(this.res.statusCode, 200);


### PR DESCRIPTION
### 解決したいこと
- ```/api/playlists/:id``` を利用したプレイリスト操作(楽曲の追加、削除)を行うテストを追加します