### PR TITLE
削除系API追加

### DIFF
--- a/common/models/inbox.json
+++ b/common/models/inbox.json
@@ -40,7 +40,6 @@
       "permission": "ALLOW",
       "property": "__get__musics"
     }
-
   ],
   "methods": []
 }

--- a/common/models/inbox.json
+++ b/common/models/inbox.json
@@ -39,6 +39,13 @@
       "principalId": "$authenticated",
       "permission": "ALLOW",
       "property": "__get__musics"
+    },
+    {
+      "accessType": "EXECUTE",
+      "principalType": "ROLE",
+      "principalId": "$owner",
+      "permission": "ALLOW",
+      "property": "__destroyById__musics"
     }
   ],
   "methods": []

--- a/common/models/playlist.json
+++ b/common/models/playlist.json
@@ -48,6 +48,13 @@
       "principalId": "$owner",
       "permission": "ALLOW",
       "property": "__get__musics"
+    },
+    {
+      "accessType": "EXECUTE",
+      "principalType": "ROLE",
+      "principalId": "$owner",
+      "permission": "ALLOW",
+      "property": "__destroyById__musics"
     }
   ],
   "methods": []

--- a/common/models/search.json
+++ b/common/models/search.json
@@ -36,6 +36,13 @@
       "principalType": "ROLE",
       "principalId": "$authenticated",
       "permission": "ALLOW"
+    },
+    {
+      "accessType": "EXECUTE",
+      "principalType": "ROLE",
+      "principalId": "$owner",
+      "permission": "ALLOW",
+      "property": "__destroyById__musics"
     }
   ],
   "methods": []

--- a/common/models/user.json
+++ b/common/models/user.json
@@ -67,6 +67,13 @@
       "principalId": "$owner",
       "permission": "ALLOW",
       "property": "__get__searches"
+    },
+    {
+      "accessType": "EXECUTE",
+      "principalType": "ROLE",
+      "principalId": "$owner",
+      "permission": "ALLOW",
+      "property": "__destroyById__playlists"
     }
   ],
   "methods": []

--- a/common/models/user.json
+++ b/common/models/user.json
@@ -74,6 +74,13 @@
       "principalId": "$owner",
       "permission": "ALLOW",
       "property": "__destroyById__playlists"
+    },
+    {
+      "accessType": "EXECUTE",
+      "principalType": "ROLE",
+      "principalId": "$owner",
+      "permission": "ALLOW",
+      "property": "__destroyById__searches"
     }
   ],
   "methods": []

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -177,6 +177,12 @@ describe('/api/users', function() {
     });
 
     describe('プレイリスト削除', function() {
+      lt.describe.whenCalledByUser(userBob, 'DELETE', '/api/users/2/playlists/1', function() {
+        it('プレイリストの所有者以外はプレイリストを削除できない', function() {
+          assert.equal(this.res.statusCode, 404);
+        });
+      });
+
       lt.describe.whenCalledByUser(userAlice, 'DELETE', '/api/users/2/playlists/1', function() {
         it('プレイリストの所有者はプレイリストを削除できる', function() {
           assert.equal(this.res.statusCode, 204);

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -105,75 +105,78 @@ describe('/api/users', function() {
     });
   });
 
-  describe('ユーザによるプレイリスト操作', function() {
-    lt.describe.whenCalledRemotely('GET', '/api/users/1/playlists', function() {
-      it('未ログインユーザはユーザのプレイリストは取得できない', function() {
-        assert.equal(this.res.statusCode, 401);
+  describe('プレイリスト関連のテスト', function() {
+    describe('ユーザによるプレイリスト操作', function() {
+      lt.describe.whenCalledRemotely('GET', '/api/users/1/playlists', function() {
+        it('未ログインユーザはユーザのプレイリストは取得できない', function() {
+          assert.equal(this.res.statusCode, 401);
+        });
+      });
+
+      lt.describe.whenCalledRemotely('POST', '/api/users/1/playlists', createPlayList, function() {
+        it('未ログインユーザはユーザのプレイリスを作成できない', function() {
+          assert.equal(this.res.statusCode, 401);
+        });
+      });
+
+      lt.describe.whenCalledByUser(userAlice, 'GET', '/api/users/2/playlists', function() {
+        it('ログインしたユーザ自身のプレイリストは取得できる', function() {
+          assert.equal(this.res.statusCode, 200);
+        });
+      });
+
+      lt.describe.whenCalledByUser(userAlice, 'POST', '/api/users/2/playlists', createPlayList, function() {
+        it('ログインユーザはユーザのプレイリスを作成できる', function() {
+          assert.equal(this.res.statusCode, 200);
+        });
+      });
+
+      lt.describe.whenCalledByUser(userAlice, 'GET', '/api/users/1/playlists', function() {
+        it('ログインしたユーザは他人のプレイリストは取得できる', function() {
+          assert.equal(this.res.statusCode, 200);
+        });
+      });
+
+      lt.describe.whenCalledByUser(userAlice, 'POST', '/api/users/1/playlists', createPlayList, function() {
+        it('ログインユーザであっても他人のプレイリスを作成できない', function() {
+          assert.equal(this.res.statusCode, 401);
+        });
       });
     });
 
-    lt.describe.whenCalledRemotely('POST', '/api/users/1/playlists', createPlayList, function() {
-      it('未ログインユーザはユーザのプレイリスを作成できない', function() {
-        assert.equal(this.res.statusCode, 401);
+    describe('プレイリストに付随する楽曲操作のテスト', function() {
+      lt.describe.whenCalledByUser(userAlice, 'POST', '/api/playlists/1/musics', {title:"NG"}, function() {
+        it('楽曲のURLが無ければプレイリストに登録できない', function() {
+          assert.equal(this.res.statusCode, 422);
+        });
       });
-    });
 
-    lt.describe.whenCalledByUser(userAlice, 'GET', '/api/users/2/playlists', function() {
-      it('ログインしたユーザ自身のプレイリストは取得できる', function() {
-        assert.equal(this.res.statusCode, 200);
+      lt.describe.whenCalledByUser(userAlice, 'POST', '/api/playlists/1/musics', {title:"NG", type:"youtube", url:"http"}, function() {
+        it('不正なURLの楽曲はプレイリストに登録できない', function() {
+          assert.equal(this.res.statusCode, 422);
+        });
       });
-    });
 
-    lt.describe.whenCalledByUser(userAlice, 'POST', '/api/users/2/playlists', createPlayList, function() {
-      it('ログインユーザはユーザのプレイリスを作成できる', function() {
-        assert.equal(this.res.statusCode, 200);
+      lt.describe.whenCalledByUser(userAlice, 'POST', '/api/playlists/1/musics', musicParams, function() {
+        it('プレイリストの所有者はプレイリストに楽曲を1曲登録できる', function() {
+          assert.equal(this.res.statusCode, 200);
+        });
       });
-    });
 
-    lt.describe.whenCalledByUser(userAlice, 'GET', '/api/users/1/playlists', function() {
-      it('ログインしたユーザは他人のプレイリストは取得できる', function() {
-        assert.equal(this.res.statusCode, 200);
+      lt.describe.whenCalledByUser(userAlice, 'DELETE', '/api/playlists/1/musics/1', function() {
+        it('プレイリストの所有者はプレイリストに楽曲を1曲削除できる', function() {
+          assert.equal(this.res.statusCode, 204);
+        });
       });
-    });
 
-    lt.describe.whenCalledByUser(userAlice, 'POST', '/api/users/1/playlists', createPlayList, function() {
-      it('ログインユーザであっても他人のプレイリスを作成できない', function() {
-        assert.equal(this.res.statusCode, 401);
+      lt.describe.whenCalledByUser(userBob, 'POST', '/api/playlists/1/musics', musicParams, function() {
+        it('プレイリストの所有者以外はプレイリストに楽曲を1曲登録できない', function() {
+          assert.equal(this.res.statusCode, 401);
+        });
       });
     });
   });
 
-  describe('ユーザによる曲のプレイリスト操作', function() {
-    lt.describe.whenCalledByUser(userAlice, 'POST', '/api/playlists/1/musics', {title:"NG"}, function() {
-      it('楽曲のURLが無ければプレイリストに登録できない', function() {
-        assert.equal(this.res.statusCode, 422);
-      });
-    });
-
-    lt.describe.whenCalledByUser(userAlice, 'POST', '/api/playlists/1/musics', {title:"NG", type:"youtube", url:"http"}, function() {
-      it('不正なURLの楽曲はプレイリストに登録できない', function() {
-        assert.equal(this.res.statusCode, 422);
-      });
-    });
-
-    lt.describe.whenCalledByUser(userAlice, 'POST', '/api/playlists/1/musics', musicParams, function() {
-      it('プレイリストの所有者はプレイリストに楽曲を1曲登録できる', function() {
-        assert.equal(this.res.statusCode, 200);
-      });
-    });
-
-    lt.describe.whenCalledByUser(userAlice, 'DELETE', '/api/playlists/1/musics/1', function() {
-      it('プレイリストの所有者はプレイリストに楽曲を1曲削除できる', function() {
-        assert.equal(this.res.statusCode, 204);
-      });
-    });
-
-    lt.describe.whenCalledByUser(userBob, 'POST', '/api/playlists/1/musics', musicParams, function() {
-      it('プレイリストの所有者以外はプレイリストに楽曲を1曲登録できない', function() {
-        assert.equal(this.res.statusCode, 401);
-      });
-    });
-  });
 
   describe('ユーザによる曲の検索操作', function() {
     describe('楽曲検索', function() {

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -175,6 +175,14 @@ describe('/api/users', function() {
         });
       });
     });
+
+    describe('プレイリスト削除', function() {
+      lt.describe.whenCalledByUser(userAlice, 'DELETE', '/api/playlists/1', function() {
+        it('プレイリストの所有者はプレイリストを削除できる', function() {
+          assert.equal(this.res.statusCode, 204);
+        });
+      });
+    });
   });
 
 

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -177,7 +177,7 @@ describe('/api/users', function() {
     });
 
     describe('プレイリスト削除', function() {
-      lt.describe.whenCalledByUser(userAlice, 'DELETE', '/api/playlists/1', function() {
+      lt.describe.whenCalledByUser(userAlice, 'DELETE', '/api/users/2/playlists/1', function() {
         it('プレイリストの所有者はプレイリストを削除できる', function() {
           assert.equal(this.res.statusCode, 204);
         });

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -267,7 +267,7 @@ describe('/api/users', function() {
       });
     });
 
-    lt.describe.whenCalledByUser(userBob, 'DELETE', '/api/searches/1/musics/32', function() {
+    lt.describe.whenCalledByUser(userBob, 'DELETE', '/api/inboxes/3/musics/32', function() {
       it('Bobのinboxに入った楽曲は受信者であるBobが削除できる', function() {
         assert.equal(this.res.statusCode, 204);
       });

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -258,6 +258,12 @@ describe('/api/users', function() {
           assert.equal(this.res.statusCode, 204);
         });
       });
+
+      lt.describe.whenCalledByUser(userAlice, 'DELETE', '/api/users/2/searches/1', function() {
+        it('検索結果の所有者は検索結果全体を削除できる', function() {
+          assert.equal(this.res.statusCode, 204);
+        });
+      });
     });
   });
 

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -236,7 +236,7 @@ describe('/api/users', function() {
     });
 
     describe('検索結果に対する操作', function() {
-      lt.describe.whenCalledByUser(userAlice, 'DELETE', '/api/searches/1/musics/1', function() {
+      lt.describe.whenCalledByUser(userAlice, 'DELETE', '/api/searches/1/musics/2', function() {
         it('プレイリストの所有者はプレイリストに楽曲を1曲削除できる', function() {
           assert.equal(this.res.statusCode, 204);
         });

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -162,6 +162,12 @@ describe('/api/users', function() {
       });
     });
 
+    lt.describe.whenCalledByUser(userAlice, 'DELETE', '/api/playlists/1/musics/1', musicParams, function() {
+      it('プレイリストの所有者はプレイリストに楽曲を1曲削除できる', function() {
+        assert.equal(this.res.statusCode, 200);
+      });
+    });
+
     lt.describe.whenCalledByUser(userBob, 'POST', '/api/playlists/1/musics', musicParams, function() {
       it('プレイリストの所有者以外はプレイリストに楽曲を1曲登録できない', function() {
         assert.equal(this.res.statusCode, 401);

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -254,7 +254,7 @@ describe('/api/users', function() {
 
     describe('検索結果に対する操作', function() {
       lt.describe.whenCalledByUser(userAlice, 'DELETE', '/api/searches/1/musics/2', function() {
-        it('プレイリストの所有者はプレイリストに楽曲を1曲削除できる', function() {
+        it('検索結果の所有者は検索結果中の楽曲を1曲削除できる', function() {
           assert.equal(this.res.statusCode, 204);
         });
       });

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -234,6 +234,14 @@ describe('/api/users', function() {
         });
       });
     });
+
+    describe('検索結果に対する操作', function() {
+      lt.describe.whenCalledByUser(userAlice, 'DELETE', '/api/searches/1/musics/1', function() {
+        it('プレイリストの所有者はプレイリストに楽曲を1曲削除できる', function() {
+          assert.equal(this.res.statusCode, 204);
+        });
+      });
+    });
   });
 
   describe('ユーザ間の楽曲の送受信', function() {

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -162,9 +162,9 @@ describe('/api/users', function() {
       });
     });
 
-    lt.describe.whenCalledByUser(userAlice, 'DELETE', '/api/playlists/1/musics/1', musicParams, function() {
+    lt.describe.whenCalledByUser(userAlice, 'DELETE', '/api/playlists/1/musics/1', function() {
       it('プレイリストの所有者はプレイリストに楽曲を1曲削除できる', function() {
-        assert.equal(this.res.statusCode, 200);
+        assert.equal(this.res.statusCode, 204);
       });
     });
 

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -266,5 +266,11 @@ describe('/api/users', function() {
         assert.equal(this.res.body[0].title, newMusic.title);
       });
     });
+
+    lt.describe.whenCalledByUser(userBob, 'DELETE', '/api/searches/1/musics/32', function() {
+      it('Bobのinboxに入った楽曲は受信者であるBobが削除できる', function() {
+        assert.equal(this.res.statusCode, 204);
+      });
+    });
   });
 });


### PR DESCRIPTION
### 解決したいこと
- 以下の削除を行うためのAPIが実装されていないので実装します
 - Musicモデルの削除
    - inboxに紐づくもの
    - playlistに紐づくもの
    - searchに紐づくもの
 - Playlistモデルの削除
 - Searchモデルの削除
