### PR TITLE
検索API機能追加(Soundcloud対応)

### DIFF
--- a/common/models/search.js
+++ b/common/models/search.js
@@ -2,13 +2,11 @@ var Youtube = require("youtube-api");
 var GLOBAL_CONFIG = require("../../global-config.js");
 
 module.exports = function(Search) {
-  Search.afterCreate = function(next) {
+  Search.youtube = function(pthis, next) {
     Youtube.authenticate({
       type: "key",
       key: GLOBAL_CONFIG.youtubeApiKey
     });
-
-    var pthis = this;
 
     Youtube.search.list({q:this.keyword, part:"snippet", maxResults:30, type:"video"}, function(err, data) {
       var youtubeUrl, orderNumber=0;
@@ -22,5 +20,10 @@ module.exports = function(Search) {
 
       next();
     });
+  };
+
+  Search.afterCreate = function(next) {
+    var pthis = this;
+    Search.youtube(pthis, next);
   };
 };

--- a/common/models/search.js
+++ b/common/models/search.js
@@ -31,10 +31,6 @@ module.exports = function(Search) {
       var youtubeUrl, orderNumber=0;
 
       tracks.forEach(function(track) {
-        //console.log(track.id);
-        //console.log(track.title);
-        //console.log(track.permalink_url);
-
         pthis.musics.create({title:track.title, type:"soundcloud", url:track.permalink_url, order:orderNumber}, function(err, obj){
         });
 

--- a/common/models/search.js
+++ b/common/models/search.js
@@ -1,14 +1,16 @@
 var Youtube = require("youtube-api");
+var Soundcloud = require('node-soundcloud');
+
 var GLOBAL_CONFIG = require("../../global-config.js");
 
 module.exports = function(Search) {
-  Search.youtube = function(pthis, next) {
+  Search.youtube = function(keyword, pthis, next) {
     Youtube.authenticate({
       type: "key",
       key: GLOBAL_CONFIG.youtubeApiKey
     });
 
-    Youtube.search.list({q:this.keyword, part:"snippet", maxResults:30, type:"video"}, function(err, data) {
+    Youtube.search.list({q:keyword, part:"snippet", maxResults:30, type:"video"}, function(err, data) {
       var youtubeUrl, orderNumber=0;
 
       data.items.forEach(function(item) {
@@ -22,8 +24,39 @@ module.exports = function(Search) {
     });
   };
 
+  Search.soundcloud = function(keyword, pthis, next) {
+    Soundcloud.init(GLOBAL_CONFIG.soundcloud);
+
+    Soundcloud.get('/tracks?q=' + keyword, function(err, tracks) {
+      var youtubeUrl, orderNumber=0;
+
+      tracks.forEach(function(track) {
+        //console.log(track.id);
+        //console.log(track.title);
+        //console.log(track.permalink_url);
+
+        pthis.musics.create({title:track.title, type:"soundcloud", url:track.permalink_url, order:orderNumber}, function(err, obj){
+        });
+
+        orderNumber++;
+      });
+
+      next();
+    });
+  };
+
   Search.afterCreate = function(next) {
     var pthis = this;
-    Search.youtube(pthis, next);
+
+    switch(this.source) {
+      case "soundcloud":
+        Search.soundcloud(this.keyword, pthis, next);
+        break;
+
+      case "youtube":
+      default:
+        Search.youtube(this.keyword, pthis, next);
+        break;
+    }
   };
 };

--- a/common/models/search.js
+++ b/common/models/search.js
@@ -41,6 +41,14 @@ module.exports = function(Search) {
     });
   };
 
+  Search.beforeSave = function(next, modelInstance) {
+    if (typeof this.source === "undefined") {
+      this.source = "youtube";
+    }
+
+    next();
+  };
+
   Search.afterCreate = function(next) {
     var pthis = this;
 

--- a/common/models/search.json
+++ b/common/models/search.json
@@ -9,6 +9,10 @@
     "TimeStamp": true
   },
   "properties": {
+    "source": {
+      "type": "string",
+      "required": true
+    },
     "keyword": {
       "type": "string",
       "required": true

--- a/global-config.js
+++ b/global-config.js
@@ -3,7 +3,10 @@
  */
 
 var conf = {
-  youtubeApiKey: (process.env.YOUTUBE_API_KEY) ? process.env.YOUTUBE_API_KEY : "(YouTube Data API Key)"
+  youtubeApiKey: (process.env.YOUTUBE_API_KEY) ? process.env.YOUTUBE_API_KEY : "(YouTube Data API Key)",
+  soundcloud: {
+    id: (process.env.SOUNDCLOUD_APP_ID) ? process.env.SOUNDCLOUD_APP_ID : "(Soundcloud Application ID)"
+  }
 };
 
 module.exports = conf;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "loopback-ds-timestamp-mixin": "^3.2.2",
     "passport-facebook": "^2.0.0",
     "serve-favicon": "^2.3.0",
+    "soundclouder": "^0.8.1",
     "youtube-api": "^1.0.1"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "node-soundcloud": "0.0.3",
     "passport-facebook": "^2.0.0",
     "serve-favicon": "^2.3.0",
-    "soundclouder": "^0.8.1",
     "youtube-api": "^1.0.1"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "loopback-connector-mongodb": "^1.13.0",
     "loopback-datasource-juggler": "^2.36.0",
     "loopback-ds-timestamp-mixin": "^3.2.2",
+    "node-soundcloud": "0.0.3",
     "passport-facebook": "^2.0.0",
     "serve-favicon": "^2.3.0",
     "soundclouder": "^0.8.1",

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -212,16 +212,26 @@ describe('/api/users', function() {
 
   describe('ユーザによる曲の検索操作', function() {
     describe('楽曲検索', function() {
-      lt.describe.whenCalledByUser(userAlice, 'POST', '/api/users/2/searches', searchParams, function() {
-        it('APIを介して楽曲の検索ができる', function() {
-          assert.equal(this.res.statusCode, 200);
+      describe('Youtube', function() {
+        lt.describe.whenCalledByUser(userAlice, 'POST', '/api/users/2/searches', searchParams, function() {
+          it('APIを介して楽曲の検索ができる', function() {
+            assert.equal(this.res.statusCode, 200);
+          });
+        });
+
+        lt.describe.whenCalledByUser(userAlice, 'POST', '/api/users/2/searches', {keyword:""}, function() {
+          it('検索キーワードが無い場合は検索が行えない', function() {
+            assert.equal(this.res.statusCode, 422);
+            assert.equal(this.res.body.error.name, "ValidationError");
+          });
         });
       });
 
-      lt.describe.whenCalledByUser(userAlice, 'POST', '/api/users/2/searches', {keyword:""}, function() {
-        it('検索キーワードが無い場合は検索が行えない', function() {
-          assert.equal(this.res.statusCode, 422);
-          assert.equal(this.res.body.error.name, "ValidationError");
+      describe('Soundcloud', function() {
+        lt.describe.whenCalledByUser(userAlice, 'POST', '/api/users/2/searches', {source:"soundcloud", keyword:"shikakun"}, function() {
+          it('APIを介して楽曲の検索ができる', function() {
+            assert.equal(this.res.statusCode, 200);
+          });
         });
       });
     });
@@ -252,9 +262,19 @@ describe('/api/users', function() {
 
     describe('検索結果の一覧取得', function() {
       lt.describe.whenCalledByUser(userAlice, 'GET', '/api/searches/1/musics', function() {
-        it.skip('楽曲の検索結果一覧を取得できる', function() {
+        it.skip('YouTube APIで検索した楽曲の検索結果一覧を取得できる', function() {
           assert.equal(this.res.statusCode, 200);
           assert.equal(this.res.body.length, 30);
+          assert.property(this.res.body[0], "createdAt");
+          assert.property(this.res.body[0], "updatedAt");
+        });
+      });
+
+      lt.describe.whenCalledByUser(userAlice, 'GET', '/api/searches/2/musics', function() {
+        it.skip('Soundcloud APIで検索した楽曲の検索結果一覧を取得できる', function() {
+          assert.equal(this.res.statusCode, 200);
+          assert.equal(this.res.body[0], "title");
+          assert.equal(this.res.body[0].source, "soundcloud");
           assert.property(this.res.body[0], "createdAt");
           assert.property(this.res.body[0], "updatedAt");
         });

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -33,7 +33,8 @@ describe('/api/users', function() {
   };
 
   var searchParams = {
-    keyword: "YMO"
+    keyword: "YMO",
+    source: "youtube"
   };
 
   var soundCloudSearchParams = {

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -243,11 +243,22 @@ describe('/api/users', function() {
 
     describe('検索結果の概要取得', function() {
       lt.describe.whenCalledByUser(userAlice, 'GET', '/api/searches/1', function() {
-        it('検索キーワードを再確認できる', function() {
+        it('YouTube 検索キーワードを再確認できる', function() {
           assert.equal(this.res.statusCode, 200);
           assert.equal(this.res.body.keyword, searchParams.keyword);
           assert.property(this.res.body, "createdAt");
           assert.property(this.res.body, "updatedAt");
+          assert.equal(this.res.body.source, "youtube");
+        });
+      });
+
+      lt.describe.whenCalledByUser(userAlice, 'GET', '/api/searches/2', function() {
+        it('Soundcloud 検索キーワードを再確認できる', function() {
+          assert.equal(this.res.statusCode, 200);
+          assert.equal(this.res.body.keyword, soundCloudSearchParams.keyword);
+          assert.property(this.res.body, "createdAt");
+          assert.property(this.res.body, "updatedAt");
+          assert.equal(this.res.body.source, "soundcloud");
         });
       });
 

--- a/test/api/rempusers.js
+++ b/test/api/rempusers.js
@@ -36,6 +36,11 @@ describe('/api/users', function() {
     keyword: "YMO"
   };
 
+  var soundCloudSearchParams = {
+    keyword: "shikakun",
+    source: "soundcloud"
+  };
+
   lt.beforeEach.withApp(app);
 
   lt.describe.whenCalledRemotely('GET', '/api/users', function() {
@@ -228,7 +233,7 @@ describe('/api/users', function() {
       });
 
       describe('Soundcloud', function() {
-        lt.describe.whenCalledByUser(userAlice, 'POST', '/api/users/2/searches', {source:"soundcloud", keyword:"shikakun"}, function() {
+        lt.describe.whenCalledByUser(userAlice, 'POST', '/api/users/2/searches', soundCloudSearchParams, function() {
           it('APIを介して楽曲の検索ができる', function() {
             assert.equal(this.res.statusCode, 200);
           });


### PR DESCRIPTION
- ```/api/users/:id/searches``` で検索結果を得る際にSoundcloudでの検索結果も得られる様にします
