### PR TITLE
Update loopback explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "youtube-api": "^1.1.0"
   },
   "optionalDependencies": {
-    "loopback-explorer": "^1.8.0"
+    "loopback-explorer": "^2.0.1"
   },
   "devDependencies": {
     "blanket": "^1.1.7",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "express-session": "^1.11.3",
     "loopback": "^2.22.1",
     "loopback-boot": "^2.12.2",
+    "loopback-component-explorer": "^2.1.0",
     "loopback-component-passport": "^1.5.0",
     "loopback-connector-mongodb": "^1.13.0",
     "loopback-datasource-juggler": "^2.40.1",
@@ -35,9 +36,6 @@
     "vimeo": "^1.1.4",
     "winston": "^1.0.1",
     "youtube-api": "^1.1.0"
-  },
-  "optionalDependencies": {
-    "loopback-explorer": "^2.0.1"
   },
   "devDependencies": {
     "blanket": "^1.1.7",

--- a/server/component-config.json
+++ b/server/component-config.json
@@ -1,0 +1,5 @@
+{
+  "loopback-component-explorer": {
+    "mountPath": "/explorer"
+  }
+}


### PR DESCRIPTION
### 解決したいこと
- APIをブラウザUIから操作できる ```loopback-explorer``` が ```loopback-component-explorer``` に変更されたため、package.jsonを更新し、```loopback-component-explorer``` の利用が行える様に修正します。
- コンポーネントの登録のために新たに ```server/component-config.json``` を追加します。
