### PR TITLE
Update npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "cors": "^2.7.1",
     "errorhandler": "^1.4.2",
     "express-session": "^1.11.3",
-    "loopback": "^2.22.1",
+    "loopback": "^2.22.2",
     "loopback-boot": "^2.12.2",
     "loopback-component-explorer": "^2.1.0",
     "loopback-component-passport": "^1.5.0",
@@ -34,8 +34,8 @@
     "serve-favicon": "^2.3.0",
     "slack-winston": "0.0.3",
     "vimeo": "^1.1.4",
-    "winston": "^1.0.1",
-    "youtube-api": "^1.1.0"
+    "winston": "^1.0.2",
+    "youtube-api": "^1.2.0"
   },
   "devDependencies": {
     "blanket": "^1.1.7",


### PR DESCRIPTION
Update npm packages.

```
"loopback" can be updated from ^2.22.1 to ^2.22.2 (Installed: 2.22.2, Latest: 2.22.2)
"winston" can be updated from ^1.0.1 to ^1.0.2 (Installed: 1.0.1, Latest: 1.0.2)
"youtube-api" can be updated from ^1.1.0 to ^1.2.0 (Installed: 1.2.0, Latest: 1.2.0)
```